### PR TITLE
Update Tags.js

### DIFF
--- a/cdk-stacks/lib/lambdas/constants/Tags.js
+++ b/cdk-stacks/lib/lambdas/constants/Tags.js
@@ -5,7 +5,7 @@
  * Tags to be applied on API calls from dashboard that accept them
  */
 const tags = {
-  "created-from": "Amazon Pinpoint LLM Chatbot"
+  "created-from": "AWS End User Messaging GenAI Chatbot"
 }
 
 export default tags


### PR DESCRIPTION
Removing reference to Amazon Pinpoint and replacing with AWS End User Messaging as default tag value.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
